### PR TITLE
New format for test-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ describe('prime number', function () {
 });
 ```
 
+#### or
+
+``` javascript
+describe('prime number', function () {
+    test({
+        name: 'isPrime({value}) should be {expected}',
+        cases: [
+            [2, true],
+            [3, true],
+            [4, false],
+            [5, true],
+            [6, false],
+            [7, true],
+            [8, false],
+            [9, false]
+        ]
+        runner: isPrime
+    });
+});
+```
+
 ## Test
 ``` bash
 $ npm test

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ $ npm test
 
 ## Change Logs
 
+* 2017/12/07 - 0.1.11
+
+  * Feature: New format for adding test-cases.
+
 * 2016/01/08 - 0.1.10
 
   * Feature: Allow `error` to be an `Error` instance, a class or a normal value.

--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ function test(testCases, runner, options) {
 
 		if ('values' in testCase) {
 			testMultiValues();
+		} else if ('cases' in testCase) {
+			testPairValues();
 		} else {
 			testSingleValue(testCase);
 		}
@@ -111,6 +113,18 @@ function test(testCases, runner, options) {
 					return values;
 				};
 			}
+		}
+
+		function testPairValues() {
+			testCase.cases.forEach(function (value) {
+				testSingleValue({
+					name: testCase.name,
+					value: value[0],
+					expected: value[1],
+					error: testCase.error,
+					options: testCase.options
+				});
+			});
 		}
 
 		function testSingleValue(theCase) {

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,7 @@ describe('mocha-cases', function () {
 
 		test(cases);
 	});
-	describe('dealing with miltiple test values', function () {
+	describe('dealing with multiple test values', function () {
 		var cases = [{
 			name: 'should handle single expected value',
 			values: [2, 4, 6, 8, 10],
@@ -44,6 +44,19 @@ describe('mocha-cases', function () {
 		}];
 
 		test(cases);
+	});
+	describe('dealing with multiple test cases as pairs value-expected', function () {
+		test({
+			name: 'should handle array of pairs {value}-{expected}',
+			cases: [
+				[2, 0],
+				[4, 0],
+				[3, 1]
+			],
+			runner: function (value) {
+				return value % 2;
+			}
+		});
 	});
 	describe('dealing value interpolating', function () {
 		var cases = [{


### PR DESCRIPTION
Hello! Thank you for your library, I find it pretty useful.

I propose to add new format for better code readability in case of many test cases.

Problem that I want to solve: it is pretty hard to associate value-expected values. The only way is to add spaces (which are often trimmed by eslint). Example of my pain is below:

![webstorm64_2017-12-07_16-10-08](https://user-images.githubusercontent.com/8207551/33712411-255d3574-db69-11e7-92f3-1f0634c4acb3.png)

I hope you will find this format usefull and merge this PR. Thanks for your attention!
